### PR TITLE
Add gist URL to the first slide

### DIFF
--- a/gistdeck.js
+++ b/gistdeck.js
@@ -32,9 +32,14 @@ function displaySlide(n) {
   $("body").scrollTop(top - padding);
 }
 
+function gistUrl() {
+  $('.path').text().trim().replace(/gist: /,'https://gist.github.com/')
+}
+
 $(document).keydown(function(e) {
   if (e.which == 37)      displaySlide(getCurrentSlideIdx()-1);
   else if (e.which == 39) displaySlide(getCurrentSlideIdx()+1);
 });
 
+$('.meta table').append('<tfoot><tr><td>' + gistUrl() + '</td></tr></tfoot>')
 displaySlide(0);


### PR DESCRIPTION
It's a long URL sures, so a bit obnoxious to manually copy down, but useful when people find screencasts/videos of presentations.  Maybe later an option for a short-url would be easy.

I didn't style it up in any way, since you might be moving where the css lives, and that would be easier to deal with after.
