### PR TITLE
Add second bookmarklet to apply slides script to gist.io pages.

### DIFF
--- a/gistdeck-io.js
+++ b/gistdeck-io.js
@@ -1,0 +1,36 @@
+var slides = $('#gistbody .file > h2');
+
+function getCurrentSlideIdx() {
+    var idx = 0;
+    var viewportBottom = $(window).scrollTop() + $(window).height();
+
+    for (var i = 0; i < slides.length; i++) {
+        if (slides.eq(i).offset().top > viewportBottom) break;
+        idx = i;
+    }
+
+    return idx;
+}
+
+function displaySlide(n) {
+    n = Math.min(n, slides.length - 1);
+    n = Math.max(n, 0);
+
+    var s = slides.eq(n);
+    var top = s.offset().top;
+
+    var padding = {
+        'DIV': s.offset().top,
+        'H1': 150,
+        'H2': 20
+    }[slides[n].tagName];
+
+    $(document).scrollTop(top - padding);
+}
+
+$(document).keydown(function(e) {
+    if (e.which == 37) displaySlide(getCurrentSlideIdx() - 1);
+    else if (e.which == 39) displaySlide(getCurrentSlideIdx() + 1);
+});
+
+displaySlide(0);

--- a/gistdeck-io.js
+++ b/gistdeck-io.js
@@ -1,4 +1,4 @@
-var slides = $('#gistbody .file > h2');
+var slides = $('#description, #gistbody .file > h1:not(:first-child), #gistbody .file > h2');
 // Cache the window jQuery object.
 $window = $(window);
 // Set a gap between each slide equal to the window height to stop slides
@@ -6,7 +6,9 @@ $window = $(window);
 slides.not(slides.first()).css('margin-top', $window.height());
 // Also set this gap between the last slide element and the slides container.
 // This stops the end slide always being at the bottom of the window.
-$('.markdown-body').css('margin-bottom', $window.height());
+$('.file').css('margin-bottom', $window.height());
+// Hide the ID
+$('#gistid').hide();
 
 function getCurrentSlideIdx() {
   var idx = 0;
@@ -34,7 +36,7 @@ function displaySlide(n) {
   var lastSlideELement = slides.eq(n+1).prev();
   var titleTop = 150;
   var contentHeight = 0;
-  if (lastSlideELement.length === 0) {
+  if (lastSlideELement.length === 0 || n === 0) {
     // lastSlideELement will be empty if we are at the last slide. In that case
     // find the last element. .nextAll().andSelf() ensures we don't end up with
     // an empty set since nextAll() will return empty if at the last element.
@@ -49,6 +51,12 @@ function displaySlide(n) {
     "H1":  titleTop,
     "H2":  20
   }[slides[n].tagName];
+
+  // If this is the first slide, we need some room above.
+  if (n === 0) {
+    padding = titleTop;
+    s.css('margin-top', padding);
+  }
 
   $(document).scrollTop(top - padding);
 }

--- a/gistdeck-io.js
+++ b/gistdeck-io.js
@@ -1,36 +1,61 @@
 var slides = $('#gistbody .file > h2');
+// Cache the window jQuery object.
+$window = $(window);
+// Set a gap between each slide equal to the window height to stop slides
+// intruding on each other. But don't do it for the first slide.
+slides.not(slides.first()).css('margin-top', $window.height());
+// Also set this gap between the last slide element and the slides container.
+// This stops the end slide always being at the bottom of the window.
+$('.markdown-body').css('margin-bottom', $window.height());
 
 function getCurrentSlideIdx() {
-    var idx = 0;
-    var viewportBottom = $(window).scrollTop() + $(window).height();
+  var idx = 0;
+  var viewportBottom = $window.scrollTop() + $window.height();
 
-    for (var i = 0; i < slides.length; i++) {
-        if (slides.eq(i).offset().top > viewportBottom) break;
-        idx = i;
-    }
+  for (var i=0; i < slides.length; i++) {
+    if (slides.eq(i).offset().top > viewportBottom) break;
+    idx = i;
+  }
 
-    return idx;
+  return idx;
 }
 
 function displaySlide(n) {
-    n = Math.min(n, slides.length - 1);
-    n = Math.max(n, 0);
+  n = Math.min(n, slides.length-1);
+  n = Math.max(n, 0);
 
-    var s = slides.eq(n);
-    var top = s.offset().top;
+  var s = slides.eq(n);
+  var top = s.offset().top;
 
-    var padding = {
-        'DIV': s.offset().top,
-        'H1': 150,
-        'H2': 20
-    }[slides[n].tagName];
+  // To vertically center the H1 slides, we must calculate the height of the
+  // slide content. To do this, get the difference between the bottom of the
+  // last and top of the first slide element. We should only do this if there
+  // is a next slide.
+  var lastSlideELement = slides.eq(n+1).prev();
+  var titleTop = 150;
+  var contentHeight = 0;
+  if (lastSlideELement.length === 0) {
+    // lastSlideELement will be empty if we are at the last slide. In that case
+    // find the last element. .nextAll().andSelf() ensures we don't end up with
+    // an empty set since nextAll() will return empty if at the last element.
+    lastSlideELement = s.nextAll().andSelf().last();
+  }
+  contentHeight = (lastSlideELement.offset().top + lastSlideELement.height()) - top;
+  // The top line is half the window plus half the content height.
+  titleTop = ($window.height()/2) - (contentHeight/2);
 
-    $(document).scrollTop(top - padding);
+  var padding = {
+    "DIV": top,
+    "H1":  titleTop,
+    "H2":  20
+  }[slides[n].tagName];
+
+  $(document).scrollTop(top - padding);
 }
 
 $(document).keydown(function(e) {
-    if (e.which == 37) displaySlide(getCurrentSlideIdx() - 1);
-    else if (e.which == 39) displaySlide(getCurrentSlideIdx() + 1);
+  if (e.which == 37)      displaySlide(getCurrentSlideIdx()-1);
+  else if (e.which == 39) displaySlide(getCurrentSlideIdx()+1);
 });
 
 displaySlide(0);

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         <ul>
           <li>
             <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://gistdeck.herokuapp.com/gistdeck.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeck</a>
-            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://raw.github.com/henrahmagix/gistdeck/add-to-gist-io/gistdeck-io.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeckIO</a>
+            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://raw.github.com/henrahmagix/gistdeck/v0.1/gistdeck-io.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeckIO</a>
           </li>
         </ul>
       </li>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         <ul>
           <li>
             <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://gistdeck.herokuapp.com/gistdeck.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeck</a>
-            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://github.com/henrahmagix/gistdeck/blob/add-to-gist-io/gistdeck-io.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeckIO</a>
+            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://raw.github.com/henrahmagix/gistdeck/add-to-gist-io/gistdeck-io.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeckIO</a>
           </li>
         </ul>
       </li>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
       text-align:left;
       line-height:36px;
     }
+    li ul {
+      list-style: none;
+      padding: 0;
+    }
     a {
       text-decoration:none;
       color: #4E51A3;
@@ -73,7 +77,7 @@
       text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
       width: inherit;
       display: inline-block;
-      margin-left: 9px;
+      margin-right: 9px;
       opacity: 1;
       -webkit-box-reflect: below 0px -webkit-gradient(linear, left top, left bottom, from(transparent), color-stop(50%, transparent), to(rgba(255,255,255,0.2)));
     }
@@ -116,7 +120,12 @@
     <ol>
       <li>
         Drag to Bookmarks Bar
-        <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://gistdeck.herokuapp.com/gistdeck.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeck</a>
+        <ul>
+          <li>
+            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://gistdeck.herokuapp.com/gistdeck.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeck</a>
+            <a class="button" href="javascript:(function(){var%20s=document.createElement('script');s.setAttribute('src','https://github.com/henrahmagix/gistdeck/blob/add-to-gist-io/gistdeck-io.js');document.getElementsByTagName('head')[0].appendChild(s);})();">GistDeckIO</a>
+          </li>
+        </ul>
       </li>
       <li>
         <a href="https://gist.github.com/b273f7a3089b1a238f5a">Visit Gist</a>


### PR DESCRIPTION
This doesn't use any CSS yet. My idea is to build a browser extension that
accepts a list of CSS files, from which you can select and it will run
this script with the chosen CSS when you're on gist.io.

Extension is being worked on [here](https://github.com/henrahmagix/gistdeck-your-css)
